### PR TITLE
update backend.rst

### DIFF
--- a/doc/howtos/backend.rst
+++ b/doc/howtos/backend.rst
@@ -247,6 +247,21 @@ Data files have to be declared in the manifest file to be loaded, they can
 be declared in the ``'data'`` list (always loaded) or in the ``'demo'`` list
 (only loaded in demonstration mode).
 
+
+Each time to aply changes from XML files you need to restart Odoo and update the module's 
+data (to install the templates) by going to :menuselection: `Settings --> Modules --> Modules -->
+Module of interest` and clicking :guilabel:`Upgrade`. 
+Also changes in py files (creating new models or fields) need restart of Odoo and module upgrade to be applied.
+
+.. tip::
+
+    Alternatively, Odoo can be restarted :option: and update modules at
+    the same time <odoo-bin -u>:
+
+    .. code-block:: console
+
+        $ odoo-bin --addons-path addons -d database-name -u module-name
+
 .. exercise:: Define demonstration data
 
     Create demonstration data filling the *Courses* model with a few


### PR DESCRIPTION
Added information to Odoo 'Building a Module' tutorial documentation:
- Restart of Odoo and module upgrade is needed to reload data from XML and some data from py files.

Description of the issue/feature this PR addresses:

Developing Odoo you have to (restart Odoo and) update module to apply changes from XML files and some data from py files. This  information is given in 'Theme Tutorial ' and 'Building a Website' but not in 'Building a Module', which is much longer and serious.

Current behavior before PR:
There is no information in 'Building a Module' Odoo tutorial that to apply changed from  XML files (and some changes from py files) the module have to be updated. 

Desired behavior after PR is merged:
Added mentioned information in proper position in 'Building a Module' Odoo tutorial.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
